### PR TITLE
chore(dependencies): upgrade to projen 0.99.17

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "constructs": "^10.5.1",
-        "projen": "^0.99.16"
+        "projen": "^0.99.17"
       },
       "devDependencies": {
         "@jsii/spec": "^1.126.0",
@@ -30,14 +30,14 @@
         "jsii-docgen": "^10.5.0",
         "jsii-pacmak": "^1.126.0",
         "jsii-rosetta": "~5.9.0",
-        "projen": "0.99.16",
+        "projen": "0.99.17",
         "ts-jest": "^29.4.6",
         "ts-node": "^10.9.2",
         "typescript": "^5.9.3"
       },
       "peerDependencies": {
         "constructs": "^10.5.1",
-        "projen": "^0.99.16"
+        "projen": "^0.99.17"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -7075,9 +7075,9 @@
       }
     },
     "node_modules/projen": {
-      "version": "0.99.16",
-      "resolved": "https://registry.npmjs.org/projen/-/projen-0.99.16.tgz",
-      "integrity": "sha512-zG39JO/f0BgNXvkevQdlexjdsSgoSShxoiNCTfgJYrDzBdjFBkHpjC06Vn4bk+95TaMfaIn7Dgbdp6jxnbvRqA==",
+      "version": "0.99.17",
+      "resolved": "https://registry.npmjs.org/projen/-/projen-0.99.17.tgz",
+      "integrity": "sha512-QhfkTKFV4ecAPesqnF9Z7WQ9sXkb7D5ESzq4ciri5m5t8hTltAuC5o4x+P9vqvt/673avSVgSI74ARYdnDAzSw==",
       "bundleDependencies": [
         "@iarna/toml",
         "case",

--- a/package.json
+++ b/package.json
@@ -49,18 +49,18 @@
     "jsii-docgen": "^10.5.0",
     "jsii-pacmak": "^1.126.0",
     "jsii-rosetta": "~5.9.0",
-    "projen": "0.99.16",
+    "projen": "0.99.17",
     "ts-jest": "^29.4.6",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.3"
   },
   "peerDependencies": {
     "constructs": "^10.5.1",
-    "projen": "^0.99.16"
+    "projen": "^0.99.17"
   },
   "dependencies": {
     "constructs": "^10.5.1",
-    "projen": "^0.99.16"
+    "projen": "^0.99.17"
   },
   "main": "lib/index.js",
   "license": "Apache-2.0",


### PR DESCRIPTION
This version of projen contains my contributions to support tag based workflow triggers

## Summary by Sourcery

Build:
- Bump projen dependency and peer dependency from 0.99.16 to 0.99.17 in package.json and lockfile.