### PR TITLE
fix: correct Makefile & fix generation of projenrc file

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,8 +42,8 @@ following steps:
        "namespace": "<your-npm-namespace-optional>"
      },
      "pythonPackage": {
-       "name": "<your-python-package-name>",
-       "prefix": "<your-python-package-prefix-optional>"
+       "name": "<your_python_package_name>",
+       "prefix": "<your_python_package_prefix_optional>"
      },
      "goPackage": "github.com/<github-user-or-org>/<github-repository>/sdk/go/v<version>",
      "dotnetPackage": {
@@ -56,6 +56,7 @@ following steps:
      }
    }
    ```
+   **Note:** The Python package name must be written with underscores instead of hyphens.
 4. Replace the placeholders in the template with the appropriate values.
 5. Create the file `.projen/tasks.json` with the following content:
    ```json

--- a/src/makefile.ts
+++ b/src/makefile.ts
@@ -58,7 +58,7 @@ export function createMakefile(project: Project, options: PulumiCrdSdksProjectOp
   makefile.addLine(`\tcrd2pulumi --python --pythonPath $(SDK_DIR)/python --pythonName $(PACKAGE_NAME_PYTHON) ${options.pythonPackage?.prefix ? '--pythonPackagePrefix $(PACKAGE_PREFIX_PYTHON)' : ''} --version $(VERSION) $(CRD_FILES)`);
   makefile.addLine('');
   makefile.addLine('build-dotnet: download');
-  makefile.addLine(`\tcrd2pulumi --dotnet --dotnetPath $(SDK_DIR)/dotnet --dotnetName $(PACKAGE_NAME_PYTHON) ${options.dotnetPackage?.namespace ? '--dotnetNamespace $(PACKAGE_NAMESPACE_DOTNET)' : ''} --version $(VERSION) $(CRD_FILES)`);
+  makefile.addLine(`\tcrd2pulumi --dotnet --dotnetPath $(SDK_DIR)/dotnet --dotnetName $(PACKAGE_NAME_DOTNET) ${options.dotnetPackage?.namespace ? '--dotnetNamespace $(PACKAGE_NAMESPACE_DOTNET)' : ''} --version $(VERSION) $(CRD_FILES)`);
   makefile.addLine('');
   makefile.addLine('build-go: download');
   makefile.addLine('\tcrd2pulumi --go --goPath $(SDK_DIR)/go --goName $(PACKAGE_NAME_GO) --version $(VERSION) $(CRD_FILES)');

--- a/src/projen-pulumi-crd-sdks.ts
+++ b/src/projen-pulumi-crd-sdks.ts
@@ -1,4 +1,4 @@
-import { License, Project, ProjenrcJson, TextFile } from 'projen';
+import { License, Project, TextFile } from 'projen';
 import { GitHub } from 'projen/lib/github';
 import * as github from './github';
 import { createMakefile } from './makefile';
@@ -11,7 +11,11 @@ export class PulumiCrdSdksProject extends Project {
   private readonly github: GitHub;
 
   constructor(options: PulumiCrdSdksProjectOptions) {
-    super(options);
+    super({
+      ...options,
+      projenrcJson: true,
+      projectTree: true,
+    });
 
     const projectIdentifiers = options.crdUrls?.map((url) => {
       try {
@@ -37,9 +41,6 @@ export class PulumiCrdSdksProject extends Project {
       mergify: false,
       pullRequestLint: false,
     });
-
-    // Generate a `.projenrc.json` file
-    new ProjenrcJson(this, {});
 
     if (options.crdUrls?.length === 0) {
       throw new Error('crdUrls cannot be empty');


### PR DESCRIPTION
- Fix Makefile to use correct language specific variables
- Let .projenrc.json be generated by default Project class

## Summary by Sourcery

Ensure .projenrc.json is generated via the base Project configuration and correct SDK naming and documentation for language-specific packages.

Bug Fixes:
- Fix Makefile to use the correct .NET package name variable when generating the .NET SDK.
- Clarify and correct Python package naming in documentation, including underscore-based naming and example placeholders.

Enhancements:
- Configure the project to generate .projenrc.json and project tree files via the default Project options instead of manual instantiation.

Documentation:
- Update README examples and add a note to document the requirement for underscores in Python package names.