### PR TITLE
chore(deps): use Node24 versions of Github Actions

### DIFF
--- a/src/github/workflow-build-check-dirty.ts
+++ b/src/github/workflow-build-check-dirty.ts
@@ -24,12 +24,17 @@ export class WorkflowBuildCheckDirty extends projen.Component {
 
     const installMise = {
       name: 'Install mise',
-      uses: 'jdx/mise-action@v2',
+      uses: 'jdx/mise-action@v4',
     };
 
     const installTools = {
       name: 'Install tools',
       run: 'mise install',
+    };
+
+    const clean = {
+      name: 'Clean',
+      run: 'make clean',
     };
 
     const build = {
@@ -53,9 +58,10 @@ export class WorkflowBuildCheckDirty extends projen.Component {
         contents: JobPermission.READ,
       },
       steps: [
-        { name: 'Checkout', uses: 'actions/checkout@v4' },
+        { name: 'Checkout', uses: 'actions/checkout@v6' },
         installMise,
         installTools,
+        clean,
         build,
         checkClean,
         failOnChanges,

--- a/src/projen-pulumi-crd-sdks.ts
+++ b/src/projen-pulumi-crd-sdks.ts
@@ -15,6 +15,7 @@ export class PulumiCrdSdksProject extends Project {
       ...options,
       projenrcJson: true,
       projectTree: true,
+      renovatebot: false, // Explicitly disable RenovateBot because UpdateCLI will be used.
     });
 
     const projectIdentifiers = options.crdUrls?.map((url) => {

--- a/test/github/workflow-build-check-dirty.test.ts
+++ b/test/github/workflow-build-check-dirty.test.ts
@@ -35,7 +35,7 @@ describe('WorkflowBuildCheckDirty', () => {
 
     // THEN
     expect(workflow).toContain('Install mise');
-    expect(workflow).toContain('uses: jdx/mise-action@v2');
+    expect(workflow).toContain('uses: jdx/mise-action@v4');
     expect(workflow).toContain('Install tools');
     expect(workflow).toContain('mise install');
   });
@@ -124,7 +124,7 @@ describe('WorkflowBuildCheckDirty', () => {
 
     // THEN
     expect(workflow).toContain('Checkout');
-    expect(workflow).toContain('actions/checkout@v4');
+    expect(workflow).toContain('actions/checkout@v6');
   });
 
   test('has correct job permissions', () => {


### PR DESCRIPTION
## Summary by Sourcery

Update GitHub workflow configuration and project settings for dependency and tooling management.

Enhancements:
- Add a clean step to the build-check-dirty workflow to run `make clean` before building.
- Explicitly disable RenovateBot in PulumiCrdSdksProject configuration in favor of UpdateCLI.

CI:
- Bump GitHub Actions versions in the build-check-dirty workflow, including mise-action and checkout, and align tests with the new versions.