### PR TITLE
feat: add more workflows and related files

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ possible yet to perform the initialization in a single step. You will need to pe
 following steps:
 
 1. Create a new directory for your project and navigate into it.
-2. Run `npx projen new npx projen new --from @containercraft/projen-pulumi-crd-sdks --synth=false --no-git` .
+2. Run `npx projen new --from @containercraft/projen-pulumi-crd-sdks --synth=false --no-git` .
 3. Now paste the following template over your `.projenrc.json` file:
    ```json
    {

--- a/src/github/workflow-build-check-dirty.ts
+++ b/src/github/workflow-build-check-dirty.ts
@@ -1,5 +1,4 @@
 import * as projen from 'projen';
-import { JobPermission } from 'projen/lib/github/workflows-model';
 
 /**
  * Component that manages the main GitHub Actions workflow.
@@ -14,58 +13,274 @@ export class WorkflowBuildCheckDirty extends projen.Component {
       return;
     }
 
-    const workflow = github.addWorkflow('main');
+    const uploadSdkAction = new projen.YamlFile(
+      project,
+      '.github/actions/upload-sdk/action.yml',
+      {
+        readonly: true,
+        committed: true,
+      },
+    );
+    uploadSdkAction.addOverride('name', 'Upload SDK asset');
+    uploadSdkAction.addOverride('description', 'Upload the SDK for a specific language as an asset for the workflow.');
+    uploadSdkAction.addOverride('inputs.language.required', 'true');
+    uploadSdkAction.addOverride('inputs.language.description', 'One of nodejs, python, dotnet, go, java');
+    uploadSdkAction.addOverride('runs.using', 'composite');
+    uploadSdkAction.addToArray('runs.steps',
+      {
+        name: 'Compress SDK folder',
+        shell: 'bash',
+        run: 'tar -zcf sdk/${{ inputs.language }}.tar.gz -C sdk/${{ inputs.language }} .',
+      },
+      {
+        name: 'Upload ${{ inputs.language }} SDK',
+        uses: 'actions/upload-artifact@b7c566a772e6b6bfb58ed0dc250532a479d7789f',
+        with: {
+          'name': '${{ inputs.language }}-sdk.tar.gz',
+          'path': '${{ github.workspace}}/sdk/${{ inputs.language }}.tar.gz',
+          'retention-days': 30,
+        },
+      },
+    );
 
-    workflow.on({
+    const downloadSdkAction = new projen.YamlFile(
+      project,
+      '.github/actions/download-sdk/action.yml',
+      {
+        readonly: true,
+        committed: true,
+      },
+    );
+    downloadSdkAction.addOverride('name', 'Download SDK asset');
+    downloadSdkAction.addOverride('description', 'Restores the SDK asset for a language.');
+    downloadSdkAction.addOverride('inputs.language.required', 'true');
+    downloadSdkAction.addOverride('inputs.language.description', 'One of nodejs, python, dotnet, go, java');
+    downloadSdkAction.addOverride('runs.using', 'composite');
+    downloadSdkAction.addToArray('runs.steps',
+      {
+        name: 'Download ${{ inputs.language }} SDK',
+        uses: 'actions/download-artifact@37930b1c2abaa49bbe596cd826c3c89aef350131',
+        with: {
+          name: '${{ inputs.language }}-sdk.tar.gz',
+          path: '${{ github.workspace }}/sdk/',
+        },
+      },
+      {
+        name: 'Uncompress SDK folder',
+        shell: 'bash',
+        run: 'tar -zxf ${{ github.workspace }}/sdk/${{ inputs.language }}.tar.gz -C ${{ github.workspace }}/sdk/${{ inputs.language }}',
+      },
+    );
+
+    const buildSdk = github.addWorkflow('build_sdk');
+
+    buildSdk.name = 'Build SDK';
+
+    buildSdk.on({
+      workflowCall: {},
+    });
+
+    const installMise = {
+      name: 'Install mise',
+      uses: 'jdx/mise-action@c1a019b8d2586943b4dbebc456323b516910e310',
+      env: {
+        MISE_FETCH_REMOTE_VERSIONS_TIMEOUT: '30s',
+      },
+      with: {
+        version: '2026.2.20',
+        github_token: '${{ secrets.GITHUB_TOKEN }}',
+        cache_save: false,
+      },
+    };
+
+    const clean = {
+      name: 'Clean SDK',
+      run: 'make clean_sdk_${{ matrix.language }}',
+    };
+
+    const build = {
+      name: 'Build SDK',
+      run: 'make build_${{ matrix.language }}',
+    };
+
+    const setupGoCache = {
+      name: 'Setup Go Cache',
+      if: "matrix.language == 'go' || contains(matrix.language, 'go')",
+      uses: 'actions/setup-go@4dc6199c7b1a012772edbd06daecab0f50c9053c',
+      with: {
+        'cache-dependency-path': 'provider/*.sum\nupstream/*.sum\nsdk/go/*.sum\nsdk/*.sum\n*.sum',
+      },
+    };
+
+    const checkClean = {
+      name: 'Check Git workspace is clean',
+      run: 'git diff --name-status --exit-code',
+    };
+
+    const failOnChanges = {
+      name: 'Fail if there are changed files',
+      run: 'git status --porcelain\n' +
+        'if [ -n "$(git status --porcelain)" ]; then echo "::error::Git workspace is not clean"; exit 1; fi',
+    };
+
+    const uploadSdk = {
+      name: 'Upload SDK',
+      uses: './.github/actions/upload-sdk',
+      with: {
+        language: '${{ matrix.language }}',
+      },
+    };
+
+    buildSdk.addJob('build_sdk', {
+      name: 'build_sdk',
+      runsOn: ['ubuntu-latest'],
+      permissions: {
+        contents: 'read',
+      },
+      strategy: {
+        matrix: {
+          domain: {
+            language: [
+              'dotnet',
+              'go',
+              'nodejs',
+              'python',
+            ],
+          },
+        },
+      },
+      steps: [
+        {
+          name: 'Checkout',
+          uses: 'actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8',
+          with: {
+            'persist-credentials': false,
+          },
+        },
+        installMise,
+        setupGoCache,
+        clean,
+        build,
+        checkClean,
+        failOnChanges,
+        uploadSdk,
+      ],
+    });
+
+    const publishSdk = github.addWorkflow('publish_sdk');
+
+    publishSdk.name = 'Publish SDK';
+
+    publishSdk.on({
+      workflowCall: {},
+    });
+    publishSdk.addJob('publish_sdk', {
+      name: 'publish_sdk',
+      runsOn: ['ubuntu-latest'],
+      permissions: {
+        contents: 'write',
+      },
+      steps: [
+        {
+          name: 'Checkout',
+          uses: 'actions/checkout@8e8c483db84b4bee98b60c0593521ed34d9990e8',
+          with: {
+            'persist-credentials': false,
+          },
+        },
+        installMise,
+        {
+          name: 'Download Node SDK',
+          uses: './.github/actions/download-sdk',
+          with: {
+            language: 'nodejs',
+          },
+        },
+        {
+          name: 'Publish Node SDK',
+          env: {
+            NPM_DIST_TAG: 'latest',
+            //NPM_TRUSTED_PUBLISHER: "true",
+            NPM_REGISTRY: 'api.repoflow.io/npm/hardes/crd-node/',
+            NPM_TOKEN: '${{ secrets.NODE_AUTH_TOKEN }}',
+          },
+          run: 'npx -p publib@latest publib-npm sdk/nodejs/dist',
+        },
+        {
+          name: 'Download Python SDK',
+          uses: './.github/actions/download-sdk',
+          with: {
+            language: 'python',
+          },
+        },
+        {
+          name: 'Publish Python SDK',
+          env: {
+            TWINE_USERNAME: 'ringods',
+            TWINE_PASSWORD: '${{ secrets.PYPI_TOKEN }}',
+            TWINE_REPOSITORY_URL: 'https://api.repoflow.io/pypi/hardes/crd-python',
+            //PYPI_TRUSTED_PUBLISHER: "true",
+          },
+          run: 'npx -p publib@latest publib-pypi sdk/python/bin/dist',
+        },
+        {
+          uses: 'pulumi/publish-go-sdk-action@v1',
+          with: {
+            'repository': '${{ github.repository }}',
+            'base-ref': '${{ github.sha }}',
+            'source': 'sdk',
+            'path': 'sdk',
+            'version': '${{ inputs.version }}',
+            'additive': false,
+            'files': 'go.*\ngo/**\n!*.tar.gz',
+          },
+        },
+      ],
+    });
+
+    const main = github.addWorkflow('main');
+
+    main.on({
       push: { branches: ['main'] },
       pullRequest: {},
       workflowDispatch: {},
     });
 
-    const installMise = {
-      name: 'Install mise',
-      uses: 'jdx/mise-action@v4',
-    };
-
-    const installTools = {
-      name: 'Install tools',
-      run: 'mise install',
-    };
-
-    const clean = {
-      name: 'Clean',
-      run: 'make clean',
-    };
-
-    const build = {
-      name: 'Build',
-      run: 'make build',
-    };
-
-    const checkClean = {
-      name: 'Check Git workspace is clean',
-      run: 'git diff --exit-code',
-    };
-
-    const failOnChanges = {
-      name: 'Fail if there are changed files',
-      run: 'if [ -n "$(git status --porcelain)" ]; then echo "::error::Git workspace is not clean"; exit 1; fi',
-    };
-
-    workflow.addJob('build', {
-      runsOn: ['ubuntu-latest'],
+    main.addJob('build_sdk', {
+      name: 'build_sdk',
       permissions: {
-        contents: JobPermission.READ,
+        contents: 'read',
       },
-      steps: [
-        { name: 'Checkout', uses: 'actions/checkout@v6' },
-        installMise,
-        installTools,
-        clean,
-        build,
-        checkClean,
-        failOnChanges,
-      ],
+      uses: './.github/workflows/build_sdk.yml',
+      secrets: 'inherit',
+    });
+
+    const release = github.addWorkflow('release');
+    release.name = 'Publish SDKs';
+
+    release.on({
+      push: {
+        tags: [
+          'v*.*.*', // TODO This must match the major version from .projenrc.json
+          '!v*.*.*-**',
+        ],
+      },
+    });
+
+    release.addJob('build_sdk', {
+      permissions: {
+        contents: 'read',
+      },
+      uses: './.github/workflows/build_sdk.yml',
+      secrets: 'inherit',
+    });
+    release.addJob('publish', {
+      permissions: {
+        contents: 'write',
+      },
+      needs: 'build_sdk',
+      uses: './.github/workflows/publish_sdk.yml',
+      secrets: 'inherit',
     });
   }
 }

--- a/src/makefile.ts
+++ b/src/makefile.ts
@@ -42,6 +42,10 @@ export function createMakefile(project: Project, options: PulumiCrdSdksProjectOp
   makefile.addLine('CRD_FILES := $(patsubst %.yaml,$(CRD_DIR)/%.yaml,$(notdir $(CRD_URLS)))');
   makefile.addLine('');
 
+  makefile.addLine('# Ensure all directories exist before evaluating targets to avoid issues with `touch` creating directories.');
+  makefile.addLine('_ := $(shell mkdir -p .make)');
+  makefile.addLine('');
+
   makefile.addLine('download: $(CRD_FILES)');
   makefile.addLine('');
 
@@ -51,29 +55,89 @@ export function createMakefile(project: Project, options: PulumiCrdSdksProjectOp
   makefile.addLine('$(CRD_DIR)/%.yaml: | $(CRD_DIR)');
   makefile.addLine('\tcurl -sL -o $@ $(subst $(CRD_DIR)/,https://github.com/cert-manager/cert-manager/raw/refs/tags/v$(VERSION)/deploy/crds/,$@)');
   makefile.addLine('');
-  makefile.addLine('build-nodejs: download');
+
+  makefile.addLine('generate_nodejs: .make/generate_nodejs');
+  makefile.addLine('build_nodejs: .make/build_nodejs');
+  makefile.addLine('.make/generate_nodejs: download');
   makefile.addLine(`\tcrd2pulumi --nodejs --nodejsPath $(SDK_DIR)/nodejs --nodejsName $(PACKAGE_NAME_NODEJS) ${options.nodePackage?.namespace ? '--nodejsNamespace $(PACKAGE_NAMESPACE_NODEJS)' : ''} --version $(VERSION) $(CRD_FILES)`);
+  makefile.addLine('\t@touch $@');
+  makefile.addLine('.make/build_nodejs: .make/generate_nodejs');
+  makefile.addLine('\tcd sdk/nodejs/ && \\');
+  makefile.addLine('\t\tnpm install && \\');
+  makefile.addLine('\t\tnpm run build && \\');
+  makefile.addLine('\t\tcp README.md ../../LICENSE package.json package-lock.json ./bin/ && \\');
+  makefile.addLine('\t\tmkdir -p dist && \\');
+  makefile.addLine('\t\tnpm pack --pack-destination dist && \\');
+  makefile.addLine('\t\trm -rf ./bin');
+  makefile.addLine('\t@touch $@');
+  makefile.addLine('clean_sdk_nodejs:');
+  makefile.addLine('\trm -rf $(SDK_DIR)/nodejs');
+  makefile.addLine('.PHONY: generate_nodejs build_nodejs clean_sdk_nodejs');
   makefile.addLine('');
-  makefile.addLine('build-python: download');
+
+  makefile.addLine('generate_python: .make/generate_python');
+  makefile.addLine('build_python: .make/build_python');
+  makefile.addLine('.make/generate_python: download');
   makefile.addLine(`\tcrd2pulumi --python --pythonPath $(SDK_DIR)/python --pythonName $(PACKAGE_NAME_PYTHON) ${options.pythonPackage?.prefix ? '--pythonPackagePrefix $(PACKAGE_PREFIX_PYTHON)' : ''} --version $(VERSION) $(CRD_FILES)`);
+  makefile.addLine('\t@touch $@');
+  makefile.addLine('.make/build_python: .make/generate_python');
+  makefile.addLine('\tcd sdk/python/ && \\');
+  makefile.addLine('\t\trm -rf ./bin/ ../python.bin/ && cp -R . ../python.bin && mv ../python.bin ./bin && \\');
+  makefile.addLine('\t\tpython3 -m venv venv && \\');
+  makefile.addLine('\t\t./venv/bin/python -m pip install build==1.2.1 && \\');
+  makefile.addLine('\t\tcd ./bin && \\');
+  makefile.addLine('\t\t../venv/bin/python -m build .');
+  makefile.addLine('\t@touch $@');
+  makefile.addLine('clean_sdk_python:');
+  makefile.addLine('\trm -rf $(SDK_DIR)/python');
+  makefile.addLine('.PHONY: generate_python build_python clean_sdk_python');
   makefile.addLine('');
-  makefile.addLine('build-dotnet: download');
+
+  makefile.addLine('generate_dotnet: .make/generate_dotnet');
+  makefile.addLine('build_dotnet: .make/build_dotnet');
+  makefile.addLine('.make/generate_dotnet: download');
   makefile.addLine(`\tcrd2pulumi --dotnet --dotnetPath $(SDK_DIR)/dotnet --dotnetName $(PACKAGE_NAME_DOTNET) ${options.dotnetPackage?.namespace ? '--dotnetNamespace $(PACKAGE_NAMESPACE_DOTNET)' : ''} --version $(VERSION) $(CRD_FILES)`);
+  makefile.addLine('\t@touch $@');
+  makefile.addLine('.make/build_dotnet: .make/generate_dotnet');
+  makefile.addLine('\tcd sdk/dotnet/ #&& dotnet build # Commented out due to https://github.com/pulumi/pulumi/issues/15874');
+  makefile.addLine('\t@touch $@');
+  makefile.addLine('clean_sdk_dotnet:');
+  makefile.addLine('\trm -rf $(SDK_DIR)/dotnet');
+  makefile.addLine('.PHONY: generate_dotnet build_dotnet clean_sdk_dotnet');
   makefile.addLine('');
-  makefile.addLine('build-go: download');
+
+  makefile.addLine('generate_go: .make/generate_go');
+  makefile.addLine('build_go: .make/build_go');
+  makefile.addLine('.make/generate_go: download');
   makefile.addLine('\tcrd2pulumi --go --goPath $(SDK_DIR)/go --goName $(PACKAGE_NAME_GO) --version $(VERSION) $(CRD_FILES)');
+  makefile.addLine('\t@touch $@');
+  makefile.addLine('.make/build_go: .make/generate_go');
+  makefile.addLine("\tcd sdk && go list \"$$(grep -e \"^module\" go.mod | cut -d ' ' -f 2)/go/...\" | xargs -I {} bash -c 'go build {} && go clean -i {}'");
+  makefile.addLine('\t@touch $@');
+  makefile.addLine('clean_sdk_go:');
+  makefile.addLine('\trm -rf $(SDK_DIR)/go');
+  makefile.addLine('.PHONY: generate_go build_go clean_sdk_go');
   makefile.addLine('');
+
   if (options.javaPackage) {
-    makefile.addLine('build-java: download');
+    makefile.addLine('generate_java: .make/generate_java');
+    makefile.addLine('build_java: .make/build_java');
+    makefile.addLine('.make/generate_java: download');
     makefile.addLine(`\tcrd2pulumi --java --javaPath $(SDK_DIR)/java --javaName $(PACKAGE_NAME_JAVA) ${options.javaPackage.basePackage ? '--javaBasePackage $(PACKAGE_BASEPACKAGE_JAVA)' : ''} --version $(VERSION) $(CRD_FILES)`);
+    makefile.addLine('\t@touch $@');
+    makefile.addLine('.make/build_java: .make/generate_java');
+    makefile.addLine('\t@touch $@');
+    makefile.addLine('clean_sdk_java:');
+    makefile.addLine('\trm -rf $(SDK_DIR)/java');
+    makefile.addLine('.PHONY: generate_java build_java clean_sdk_java');
     makefile.addLine('');
   }
-  makefile.addLine(`build: build-nodejs build-python build-dotnet build-go ${options.javaPackage ? 'build-java' : ''}`);
+
+  makefile.addLine(`build: build_nodejs build_python build_dotnet build_go${options.javaPackage ? ' build_java' : ''}`);
   makefile.addLine('');
-  makefile.addLine('clean-sdk:');
-  makefile.addLine('\trm -rf $(SDK_DIR)');
+  makefile.addLine('clean_sdk: clean_sdk_nodejs clean_sdk_python clean_sdk_dotnet clean_sdk_go');
   makefile.addLine('');
-  makefile.addLine('clean: clean-sdk');
+  makefile.addLine('clean: clean_sdk');
   makefile.addLine('\trm -rf $(CRD_DIR)');
   makefile.addLine('');
 

--- a/src/projen-pulumi-crd-sdks.ts
+++ b/src/projen-pulumi-crd-sdks.ts
@@ -1,4 +1,4 @@
-import { License, Project, TextFile } from 'projen';
+import { IgnoreFile, License, Project, TextFile } from 'projen';
 import { GitHub } from 'projen/lib/github';
 import * as github from './github';
 import { createMakefile } from './makefile';
@@ -55,13 +55,36 @@ export class PulumiCrdSdksProject extends Project {
 
     new TextFile(this, 'mise.toml', {
       lines: [
+        '[plugins]',
+        'vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"',
+        '',
+        '[env]',
+        '_.vfox-pulumi = { module_path = "sdk" } # Sets GO_VERSION_MISE and PULUMI_VERSION_MISE',
+        '',
         '[tools]',
+        'go = "{{ env.GO_VERSION_MISE }}"',
         "'github:pulumi/crd2pulumi' = '1.6.1'",
+        '"vfox:version-fox/vfox-dotnet" = "8.0.20"',
+        '',
       ],
     });
 
     new github.WorkflowBuildCheckDirty(this);
     new BuildTask(this);
     createMakefile(this, options);
+
+    this.gitattributes.addAttributes('sdk/**/*', 'linguist-generated=true');
+
+    this.gitignore.exclude('package-lock.json');
+    this.gitignore.exclude('.make');
+
+    const sdkIgnore = new IgnoreFile(this, 'sdk/.gitignore');
+    sdkIgnore.exclude('/nodejs/bin/');
+    sdkIgnore.exclude('/nodejs/dist/');
+    sdkIgnore.exclude('/nodejs/node_modules/');
+    sdkIgnore.exclude('/python/bin');
+    sdkIgnore.exclude('/python/venv');
+    sdkIgnore.exclude('/python/*.egg-info');
+    sdkIgnore.exclude('__pycache__');
   }
 }

--- a/test/github/workflow-build-check-dirty.test.ts
+++ b/test/github/workflow-build-check-dirty.test.ts
@@ -31,13 +31,11 @@ describe('WorkflowBuildCheckDirty', () => {
     // WHEN
     new WorkflowBuildCheckDirty(project);
     const snapshot = synthSnapshot(project);
-    const workflow = snapshot['.github/workflows/main.yml'];
+    const workflow = snapshot['.github/workflows/build_sdk.yml'];
 
     // THEN
     expect(workflow).toContain('Install mise');
-    expect(workflow).toContain('uses: jdx/mise-action@v4');
-    expect(workflow).toContain('Install tools');
-    expect(workflow).toContain('mise install');
+    expect(workflow).toContain('uses: jdx/mise-action@');
   });
 
   test('contains build step', () => {
@@ -50,10 +48,10 @@ describe('WorkflowBuildCheckDirty', () => {
     // WHEN
     new WorkflowBuildCheckDirty(project);
     const snapshot = synthSnapshot(project);
-    const workflow = snapshot['.github/workflows/main.yml'];
+    const workflow = snapshot['.github/workflows/build_sdk.yml'];
 
     // THEN
-    expect(workflow).toContain('make build');
+    expect(workflow).toContain('make build_${{ matrix.language }}');
   });
 
   test('contains git clean check', () => {
@@ -66,11 +64,11 @@ describe('WorkflowBuildCheckDirty', () => {
     // WHEN
     new WorkflowBuildCheckDirty(project);
     const snapshot = synthSnapshot(project);
-    const workflow = snapshot['.github/workflows/main.yml'];
+    const workflow = snapshot['.github/workflows/build_sdk.yml'];
 
     // THEN
     expect(workflow).toContain('Check Git workspace is clean');
-    expect(workflow).toContain('git diff --exit-code');
+    expect(workflow).toContain('git diff --name-status --exit-code');
   });
 
   test('fails on changed files', () => {
@@ -83,7 +81,7 @@ describe('WorkflowBuildCheckDirty', () => {
     // WHEN
     new WorkflowBuildCheckDirty(project);
     const snapshot = synthSnapshot(project);
-    const workflow = snapshot['.github/workflows/main.yml'];
+    const workflow = snapshot['.github/workflows/build_sdk.yml'];
 
     // THEN
     expect(workflow).toContain('Fail if there are changed files');
@@ -120,11 +118,11 @@ describe('WorkflowBuildCheckDirty', () => {
     // WHEN
     new WorkflowBuildCheckDirty(project);
     const snapshot = synthSnapshot(project);
-    const workflow = snapshot['.github/workflows/main.yml'];
+    const workflow = snapshot['.github/workflows/build_sdk.yml'];
 
     // THEN
     expect(workflow).toContain('Checkout');
-    expect(workflow).toContain('actions/checkout@v6');
+    expect(workflow).toContain('actions/checkout@');
   });
 
   test('has correct job permissions', () => {
@@ -154,7 +152,7 @@ describe('WorkflowBuildCheckDirty', () => {
     // WHEN
     new WorkflowBuildCheckDirty(project);
     const snapshot = synthSnapshot(project);
-    const workflow = snapshot['.github/workflows/main.yml'];
+    const workflow = snapshot['.github/workflows/build_sdk.yml'];
 
     // THEN
     expect(workflow).toContain('runs-on: ubuntu-latest');
@@ -210,8 +208,8 @@ describe('WorkflowBuildCheckDirty', () => {
 
     // THEN
     expect(workflow).toBeDefined();
-    expect(workflow).toContain('mise install');
-    expect(workflow).toContain('make build');
+    expect(workflow).toContain('build_sdk:');
+    expect(workflow).toContain('uses: ./.github/workflows/build_sdk.yml');
   });
 
 });

--- a/test/projen-pulumi-crd-sdks.test.ts
+++ b/test/projen-pulumi-crd-sdks.test.ts
@@ -39,8 +39,17 @@ describe('PulumiCrdSdksProject', () => {
     const snapshot = synthSnapshot(project);
 
     // THEN
-    expect(snapshot['mise.toml']).toBe(`[tools]
-'github:pulumi/crd2pulumi' = '1.6.1'`,
+    expect(snapshot['mise.toml']).toBe(`[plugins]
+vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"
+
+[env]
+_.vfox-pulumi = { module_path = "sdk" } # Sets GO_VERSION_MISE and PULUMI_VERSION_MISE
+
+[tools]
+go = "{{ env.GO_VERSION_MISE }}"
+'github:pulumi/crd2pulumi' = '1.6.1'
+"vfox:version-fox/vfox-dotnet" = "8.0.20"
+`,
     );
   });
 


### PR DESCRIPTION
- updated the Makefile
- added a release workflow
- separated some steps in actions

## Summary by Sourcery

Introduce dedicated SDK build and publish workflows and align the Makefile and project configuration to support multi-language SDK assets.

Enhancements:
- Add composite GitHub Actions to upload and download language-specific SDK artifacts and wire them into new reusable build and publish workflows.
- Refine the SDK build pipeline to run per-language builds via matrix strategy, add Go build caching, and tighten git cleanliness checks.
- Restructure the Makefile into per-language generate/build/clean targets with incremental markers, and add directory bootstrapping to avoid flaky builds.
- Extend project configuration to manage SDK-related tooling via mise and vfox, mark generated SDK files for linguist, and ignore SDK build artifacts in git.

Build:
- Add reusable GitHub workflows for building SDKs on main and publishing versioned SDKs on tag pushes, and connect them from the primary workflow.

Documentation:
- Fix the README initialization command for creating a new project from this template.

Tests:
- Update workflow and project tests to assert the new build_sdk workflow file, updated commands, and revised configuration content.

Chores:
- Add SDK-specific .gitignore under sdk/ and exclude build metadata directories from version control.