### PR TITLE
feat: add UpdateCLI configuration

### DIFF
--- a/src/github/workflow-build-check-dirty.ts
+++ b/src/github/workflow-build-check-dirty.ts
@@ -110,7 +110,7 @@ export class WorkflowBuildCheckDirty extends projen.Component {
       permissions: {
         contents: 'write',
         pullRequests: 'write',
-        idTokens: 'write',
+        idToken: 'write',
       },
       steps: [
         checkOut,

--- a/src/projen-pulumi-crd-sdks.ts
+++ b/src/projen-pulumi-crd-sdks.ts
@@ -4,6 +4,7 @@ import * as github from './github';
 import { createMakefile } from './makefile';
 import { BuildTask } from './tasks';
 import { PulumiCrdSdksProjectOptions } from './types';
+import { createUpdateCliConfig } from './updatecli';
 
 
 export class PulumiCrdSdksProject extends Project {
@@ -72,6 +73,7 @@ export class PulumiCrdSdksProject extends Project {
     new github.WorkflowBuildCheckDirty(this);
     new BuildTask(this);
     createMakefile(this, options);
+    createUpdateCliConfig(this, options);
 
     this.gitattributes.addAttributes('sdk/**/*', 'linguist-generated=true');
 

--- a/src/updatecli.ts
+++ b/src/updatecli.ts
@@ -50,5 +50,5 @@ export function createUpdateCliConfig(project: Project, options: PulumiCrdSdksPr
   valuesUpstreamFile.addOverride('upstream.repository', options.upstreamProject?.repository);
   valuesUpstreamFile.addOverride('upstream.env_token', 'UPDATECLI_GITHUB_TOKEN');
 
-  return [valuesUpstreamFile, valuesUpstreamFile, valuesUpstreamFile];
+  return [composeFile, valuesScmFile, valuesUpstreamFile];
 }

--- a/src/updatecli.ts
+++ b/src/updatecli.ts
@@ -1,0 +1,54 @@
+import { Project, YamlFile } from 'projen';
+import { PulumiCrdSdksProjectOptions } from './types';
+
+export function createUpdateCliConfig(project: Project, options: PulumiCrdSdksProjectOptions): YamlFile[] {
+
+  const composeFile = new YamlFile(
+    project,
+    'updatecli-compose.yaml',
+    {
+      readonly: true,
+      committed: true,
+    },
+  );
+  composeFile.addToArray('policies',
+    {
+      name: 'Update upstream CRD version',
+      policy: 'api.repoflow.io/hardes/updatecli-policies/containercraft/crd-pulumi-sdk:0.0.6',
+      values: [
+        'updatecli/values.d/scm.yaml',
+        'updatecli/values.d/upstream.yaml',
+      ],
+    },
+  );
+
+  const valuesScmFile = new YamlFile(
+    project,
+    'updatecli/values.d/scm.yaml',
+    {
+      readonly: true,
+      committed: true,
+    },
+  );
+  valuesScmFile.addOverride('scm.kind', 'github');
+  valuesScmFile.addOverride('scm.owner', 'experimentale');
+  valuesScmFile.addOverride('scm.repository', 'pulumi-crd-certmanager');
+  valuesScmFile.addOverride('scm.username', 'ringods');
+  valuesScmFile.addOverride('scm.env_token', 'UPDATECLI_GITHUB_TOKEN');
+  valuesScmFile.addOverride('scm.branch', 'main');
+
+  const valuesUpstreamFile = new YamlFile(
+    project,
+    'updatecli/values.d/upstream.yaml',
+    {
+      readonly: true,
+      committed: true,
+    },
+  );
+  valuesUpstreamFile.addOverride('upstream.kind', 'github');
+  valuesUpstreamFile.addOverride('upstream.owner', options.upstreamProject?.owner);
+  valuesUpstreamFile.addOverride('upstream.repository', options.upstreamProject?.repository);
+  valuesUpstreamFile.addOverride('upstream.env_token', 'UPDATECLI_GITHUB_TOKEN');
+
+  return [valuesUpstreamFile, valuesUpstreamFile, valuesUpstreamFile];
+}


### PR DESCRIPTION
Add the UpdateCLI configuration to the template setup.

Files generated:
- updatecli-compose.yaml
- updatecli/values.d/scm.yaml
- updatecli/values.d/upstream.yaml

## Summary by Sourcery

Add automated UpdateCLI configuration generation for Pulumi CRD SDK projects and correct GitHub workflow permissions.

New Features:
- Generate an UpdateCLI compose configuration and values files for Pulumi CRD SDK projects as part of project setup.

Bug Fixes:
- Fix the GitHub workflow build-check-dirty permissions key from idTokens to idToken to align with GitHub Actions expectations.