### PR TITLE
feat: use Github app authentication

### DIFF
--- a/src/github/workflow-build-check-dirty.ts
+++ b/src/github/workflow-build-check-dirty.ts
@@ -131,13 +131,14 @@ export class WorkflowBuildCheckDirty extends projen.Component {
         {
           name: 'Check for a new version in the upstream repository',
           id: 'tag-replay',
-          uses: 'ContainerCraft/git-tag-replay@04f45e2b0ae278b60ab4e3a09402b073752998d4',
+          uses: 'ContainerCraft/git-tag-replay@55ee55afb4ffed33aa2662d3e25d5253cf0a7809',
           with: {
-            upstream_owner: 'cert-manager',
-            upstream_repository: 'cert-manager',
-            upstream_token: '${{ secrets.GITHUB_TOKEN }}',
-            token: '${{ secrets.GITHUB_TOKEN }}',
-            minimum_version: '${{ steps.latest_version_from_projenrc.outputs.result }}',
+            'upstream_owner': 'cert-manager',
+            'upstream_repository': 'cert-manager',
+            'client-id': '${{ secrets.CRD_GH_CLIENT_ID }}',
+            'private-key': '${{ secrets.CRD_GH_PRIVATE_KEY }}',
+            'installation-id': '${{ secrets.CRD_GH_INSTALLATION_ID }}',
+            'minimum_version': '${{ steps.latest_version_from_projenrc.outputs.result }}',
           },
         },
         {
@@ -149,7 +150,9 @@ export class WorkflowBuildCheckDirty extends projen.Component {
           run: 'updatecli compose diff',
           env: {
             NEXT_VERSION: '${{ steps.tag-replay.outputs.nextTag }}',
-            UPDATECLI_GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}',
+            UPDATECLI_GITHUB_APP_CLIENT_ID: '${{ secrets.CRD_GH_CLIENT_ID }}',
+            UPDATECLI_GITHUB_APP_PRIVATE_KEY: '${{ secrets.CRD_GH_PRIVATE_KEY }}',
+            UPDATECLI_GITHUB_APP_INSTALLATION_ID: '${{ secrets.CRD_GH_INSTALLATION_ID }}',
           },
         },
         {
@@ -157,7 +160,9 @@ export class WorkflowBuildCheckDirty extends projen.Component {
           run: 'updatecli compose apply',
           env: {
             NEXT_VERSION: '${{ steps.tag-replay.outputs.nextTag }}',
-            UPDATECLI_GITHUB_TOKEN: '${{ secrets.GITHUB_TOKEN }}',
+            UPDATECLI_GITHUB_APP_CLIENT_ID: '${{ secrets.CRD_GH_CLIENT_ID }}',
+            UPDATECLI_GITHUB_APP_PRIVATE_KEY: '${{ secrets.CRD_GH_PRIVATE_KEY }}',
+            UPDATECLI_GITHUB_APP_INSTALLATION_ID: '${{ secrets.CRD_GH_INSTALLATION_ID }}',
           },
         },
       ],

--- a/src/updatecli.ts
+++ b/src/updatecli.ts
@@ -14,7 +14,7 @@ export function createUpdateCliConfig(project: Project, options: PulumiCrdSdksPr
   composeFile.addToArray('policies',
     {
       name: 'Update upstream CRD version',
-      policy: 'api.repoflow.io/hardes/updatecli-policies/containercraft/crd-pulumi-sdk:0.0.6',
+      policy: 'api.repoflow.io/hardes/updatecli-policies/containercraft/crd-pulumi-sdk:0.0.7',
       values: [
         'updatecli/values.d/scm.yaml',
         'updatecli/values.d/upstream.yaml',
@@ -34,7 +34,6 @@ export function createUpdateCliConfig(project: Project, options: PulumiCrdSdksPr
   valuesScmFile.addOverride('scm.owner', 'experimentale');
   valuesScmFile.addOverride('scm.repository', 'pulumi-crd-certmanager');
   valuesScmFile.addOverride('scm.username', 'ringods');
-  valuesScmFile.addOverride('scm.env_token', 'UPDATECLI_GITHUB_TOKEN');
   valuesScmFile.addOverride('scm.branch', 'main');
 
   const valuesUpstreamFile = new YamlFile(
@@ -48,7 +47,6 @@ export function createUpdateCliConfig(project: Project, options: PulumiCrdSdksPr
   valuesUpstreamFile.addOverride('upstream.kind', 'github');
   valuesUpstreamFile.addOverride('upstream.owner', options.upstreamProject?.owner);
   valuesUpstreamFile.addOverride('upstream.repository', options.upstreamProject?.repository);
-  valuesUpstreamFile.addOverride('upstream.env_token', 'UPDATECLI_GITHUB_TOKEN');
 
   return [composeFile, valuesScmFile, valuesUpstreamFile];
 }


### PR DESCRIPTION
## Summary by Sourcery

Switch GitHub workflows and Updatecli configuration to use GitHub App-based authentication instead of personal access tokens.

Enhancements:
- Update git-tag-replay GitHub Action version to align with GitHub App authentication support.
- Bump Updatecli policy reference for CRD Pulumi SDK updates to the latest version.
- Remove token-based SCM and upstream configuration in Updatecli values in favor of app-based credentials passed via environment.