### PR TITLE
chore(deps): bump UpdateCLI policies version

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ It is part 1 of a 3-part setup comprised of:
 * [ContainerCraft/git-tag-replay](https://github.com/ContainerCraft/git-tag-replay) - A Github Action that
   replays Git tags from an upstream repository to a downstream repository.
 * [ContainerCraft/updatecli-policies](https://github.com/ContainerCraft/updatecli-policies) - A repository
-  containing UpdateCli policies to update dependencies when new versions are detected by `git-tag-replay`.
+  containing Updatecli policies to update dependencies when new versions are detected by `git-tag-replay`.
 
 ## Usage
 

--- a/README.md
+++ b/README.md
@@ -8,6 +8,16 @@ This project is specifically designed to generate Pulumi SDKs for
 Kubernetes Custom Resource Definitions (CRDs), allowing developers to easily 
 integrate custom resources into their Pulumi-based infrastructure as code projects.
 
+It is part 1 of a 3-part setup comprised of:
+
+* [ContainerCraft/projen-pulumi-crd-sdks](https://github.com/ContainerCraft/projen-pulumi-crd-sdks) - A
+  [Projen](https://projen.io/) project type that manages projects handling Pulumi SDKs for Kubernetes Custom Resources.
+  **(this repository)**
+* [ContainerCraft/git-tag-replay](https://github.com/ContainerCraft/git-tag-replay) - A Github Action that
+  replays Git tags from an upstream repository to a downstream repository.
+* [ContainerCraft/updatecli-policies](https://github.com/ContainerCraft/updatecli-policies) - A repository
+  containing UpdateCli policies to update dependencies when new versions are detected by `git-tag-replay`.
+
 ## Usage
 
 If you have a Kubernetes operator containing CRDs that you want to integrate into Pulumi, 

--- a/src/updatecli.ts
+++ b/src/updatecli.ts
@@ -14,7 +14,7 @@ export function createUpdateCliConfig(project: Project, options: PulumiCrdSdksPr
   composeFile.addToArray('policies',
     {
       name: 'Update upstream CRD version',
-      policy: 'api.repoflow.io/hardes/updatecli-policies/containercraft/crd-pulumi-sdk:0.0.7',
+      policy: 'api.repoflow.io/hardes/updatecli-policies/containercraft/crd-pulumi-sdk:0.0.9',
       values: [
         'updatecli/values.d/scm.yaml',
         'updatecli/values.d/upstream.yaml',


### PR DESCRIPTION
## Summary by Sourcery

Document the repository's role within a three-part Pulumi CRD SDK tooling setup and update the configured UpdateCli policy version for CRD SDK updates.

Enhancements:
- Bump the UpdateCli CRD Pulumi SDK policy reference from version 0.0.7 to 0.0.9 in the update configuration.

Documentation:
- Explain how this repository fits into a three-part setup alongside git-tag-replay and updatecli-policies.