### PR TITLE
fix: switch to the publicly published policies

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,8 @@ It is part 1 of a 3-part setup comprised of:
 * [ContainerCraft/git-tag-replay](https://github.com/ContainerCraft/git-tag-replay) - A Github Action that
   replays Git tags from an upstream repository to a downstream repository.
 * [ContainerCraft/updatecli-policies](https://github.com/ContainerCraft/updatecli-policies) - A repository
-  containing Updatecli policies to update dependencies when new versions are detected by `git-tag-replay`.
+  containing [Updatecli](https://www.updatecli.io/) policies to update dependencies when new versions are 
+  detected by `git-tag-replay`.
 
 ## Usage
 

--- a/src/github/workflow-build-check-dirty.ts
+++ b/src/github/workflow-build-check-dirty.ts
@@ -125,10 +125,6 @@ export class WorkflowBuildCheckDirty extends projen.Component {
           },
         },
         {
-          name: 'Login to Repoflow Registry',
-          run: 'docker login -u ringods -p ${{ secrets.PAT_REPOFLOW }} api.repoflow.io',
-        },
-        {
           name: 'Check for a new version in the upstream repository',
           id: 'tag-replay',
           uses: 'ContainerCraft/git-tag-replay@55ee55afb4ffed33aa2662d3e25d5253cf0a7809',

--- a/src/updatecli.ts
+++ b/src/updatecli.ts
@@ -14,7 +14,7 @@ export function createUpdateCliConfig(project: Project, options: PulumiCrdSdksPr
   composeFile.addToArray('policies',
     {
       name: 'Update upstream CRD version',
-      policy: 'api.repoflow.io/hardes/updatecli-policies/containercraft/crd-pulumi-sdk:0.0.9',
+      policy: 'ghcr.io/containercraft/updatecli-policies/crd-pulumi-sdk:0.1.0',
       values: [
         'updatecli/values.d/scm.yaml',
         'updatecli/values.d/upstream.yaml',


### PR DESCRIPTION
## Summary by Sourcery

Switch Updatecli to use the publicly published CRD Pulumi SDK policy image and remove the now-unneeded private registry login step.

Enhancements:
- Update the Updatecli policy reference to use the public ghcr.io ContainerCraft CRD Pulumi SDK policy image.

Documentation:
- Clarify README documentation by linking to the official Updatecli website when describing the policies repository.