### PR TITLE
fix: configure the local project too

### DIFF
--- a/API.md
+++ b/API.md
@@ -1186,6 +1186,7 @@ const pulumiCrdSdksProjectOptions: PulumiCrdSdksProjectOptions = { ... }
 | <code><a href="#@containercraft/projen-pulumi-crd-sdks.PulumiCrdSdksProjectOptions.property.dotnetPackage">dotnetPackage</a></code> | <code><a href="#@containercraft/projen-pulumi-crd-sdks.DotnetPackageInfo">DotnetPackageInfo</a></code> | .NET Nuget package details. |
 | <code><a href="#@containercraft/projen-pulumi-crd-sdks.PulumiCrdSdksProjectOptions.property.goPackage">goPackage</a></code> | <code>string</code> | Go package details. |
 | <code><a href="#@containercraft/projen-pulumi-crd-sdks.PulumiCrdSdksProjectOptions.property.javaPackage">javaPackage</a></code> | <code><a href="#@containercraft/projen-pulumi-crd-sdks.JavaPackageInfo">JavaPackageInfo</a></code> | Java package details. |
+| <code><a href="#@containercraft/projen-pulumi-crd-sdks.PulumiCrdSdksProjectOptions.property.localProject">localProject</a></code> | <code><a href="#@containercraft/projen-pulumi-crd-sdks.GithubRepository">GithubRepository</a></code> | Github location of the local project which will contain the generated SDKs. |
 | <code><a href="#@containercraft/projen-pulumi-crd-sdks.PulumiCrdSdksProjectOptions.property.nodePackage">nodePackage</a></code> | <code><a href="#@containercraft/projen-pulumi-crd-sdks.NodePackageInfo">NodePackageInfo</a></code> | NPM package details. |
 | <code><a href="#@containercraft/projen-pulumi-crd-sdks.PulumiCrdSdksProjectOptions.property.pythonPackage">pythonPackage</a></code> | <code><a href="#@containercraft/projen-pulumi-crd-sdks.PythonPackageInfo">PythonPackageInfo</a></code> | Python package details. |
 | <code><a href="#@containercraft/projen-pulumi-crd-sdks.PulumiCrdSdksProjectOptions.property.upstreamProject">upstreamProject</a></code> | <code><a href="#@containercraft/projen-pulumi-crd-sdks.GithubRepository">GithubRepository</a></code> | Github location of the upstream project to track for new releases. |
@@ -1428,6 +1429,18 @@ public readonly javaPackage: JavaPackageInfo;
 - *Type:* <a href="#@containercraft/projen-pulumi-crd-sdks.JavaPackageInfo">JavaPackageInfo</a>
 
 Java package details.
+
+---
+
+##### `localProject`<sup>Optional</sup> <a name="localProject" id="@containercraft/projen-pulumi-crd-sdks.PulumiCrdSdksProjectOptions.property.localProject"></a>
+
+```typescript
+public readonly localProject: GithubRepository;
+```
+
+- *Type:* <a href="#@containercraft/projen-pulumi-crd-sdks.GithubRepository">GithubRepository</a>
+
+Github location of the local project which will contain the generated SDKs.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -41,6 +41,10 @@ following steps:
      "type": "@containercraft/projen-pulumi-crd-sdks.PulumiCrdSdksProject",
      "name": "<your-project-name>",
      "latestVersionOnBranch": "1.0.0",
+     "localProject": {
+       "owner": "<github-user-or-org>",
+       "repository": "<github-repository>"
+     },
      "upstreamProject": {
        "owner": "<github-user-or-org>",
        "repository": "<github-repository>"

--- a/src/types.ts
+++ b/src/types.ts
@@ -73,6 +73,11 @@ export interface GithubRepository {
 
 export interface PulumiCrdSdksProjectOptions extends ProjectOptions {
   /**
+   * Github location of the local project which will contain the generated SDKs.
+   */
+  readonly localProject?: GithubRepository;
+
+  /**
    * Github location of the upstream project to track for new releases.
    */
   readonly upstreamProject?: GithubRepository;

--- a/src/updatecli.ts
+++ b/src/updatecli.ts
@@ -31,8 +31,8 @@ export function createUpdateCliConfig(project: Project, options: PulumiCrdSdksPr
     },
   );
   valuesScmFile.addOverride('scm.kind', 'github');
-  valuesScmFile.addOverride('scm.owner', 'experimentale');
-  valuesScmFile.addOverride('scm.repository', 'pulumi-crd-certmanager');
+  valuesScmFile.addOverride('scm.owner', options.localProject?.owner);
+  valuesScmFile.addOverride('scm.repository', options.localProject?.repository);
   valuesScmFile.addOverride('scm.username', 'ringods');
   valuesScmFile.addOverride('scm.branch', 'main');
 

--- a/test/github/workflow-build-check-dirty.test.ts
+++ b/test/github/workflow-build-check-dirty.test.ts
@@ -177,6 +177,10 @@ describe('WorkflowBuildCheckDirty', () => {
     const project = new PulumiCrdSdksProject({
       name: 'pulumi-k8s-test',
       crdUrls: ['https://example.com/crds.yaml'],
+      localProject: {
+        owner: 'experimentale',
+        repository: 'pulumi-crd-certmanager',
+      },
       upstreamProject: {
         owner: 'cert-manager',
         repository: 'cert-manager',
@@ -205,11 +209,14 @@ describe('WorkflowBuildCheckDirty', () => {
     // WHEN
     const snapshot = synthSnapshot(project);
     const workflow = snapshot['.github/workflows/main.yml'];
+    const updatecli = snapshot['updatecli/values.d/scm.yaml'];
 
     // THEN
     expect(workflow).toBeDefined();
     expect(workflow).toContain('build_sdk:');
     expect(workflow).toContain('uses: ./.github/workflows/build_sdk.yml');
+    expect(updatecli).toContain('owner: experimentale');
+    expect(updatecli).toContain('repository: pulumi-crd-certmanager');
   });
 
 });


### PR DESCRIPTION
## Summary by Sourcery

Make the UpdateCli SCM configuration use a configurable local GitHub project for generated SDKs instead of hardcoded values.

New Features:
- Add an optional localProject GitHub repository configuration to PulumiCrdSdksProject options to represent the local SDK host repository.

Enhancements:
- Wire the localProject option into the generated updatecli SCM configuration for owner and repository fields.

Documentation:
- Document the new localProject configuration in the README project configuration example.

Tests:
- Extend the workflow build dirty check test to configure a localProject and assert the generated UpdateCli SCM owner and repository values.