### PR TITLE
fix: move top-level `mise.toml` to `.config` folder

### DIFF
--- a/src/projen-pulumi-crd-sdks.ts
+++ b/src/projen-pulumi-crd-sdks.ts
@@ -54,7 +54,7 @@ export class PulumiCrdSdksProject extends Project {
       copyrightPeriod: '2025-2026',
     });
 
-    new TextFile(this, 'mise.toml', {
+    new TextFile(this, '.config/mise.toml', {
       lines: [
         '[plugins]',
         'vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"',
@@ -64,7 +64,7 @@ export class PulumiCrdSdksProject extends Project {
         '',
         '[tools]',
         'go = "{{ env.GO_VERSION_MISE }}"',
-        "'github:pulumi/crd2pulumi' = '1.6.1'",
+        "'github:pulumi/crd2pulumi' = '1.6.2'",
         '"vfox:version-fox/vfox-dotnet" = "8.0.20"',
         '',
       ],

--- a/test/projen-pulumi-crd-sdks.test.ts
+++ b/test/projen-pulumi-crd-sdks.test.ts
@@ -39,7 +39,7 @@ describe('PulumiCrdSdksProject', () => {
     const snapshot = synthSnapshot(project);
 
     // THEN
-    expect(snapshot['mise.toml']).toBe(`[plugins]
+    expect(snapshot['.config/mise.toml']).toBe(`[plugins]
 vfox-pulumi = "https://github.com/pulumi/vfox-pulumi"
 
 [env]
@@ -47,7 +47,7 @@ _.vfox-pulumi = { module_path = "sdk" } # Sets GO_VERSION_MISE and PULUMI_VERSIO
 
 [tools]
 go = "{{ env.GO_VERSION_MISE }}"
-'github:pulumi/crd2pulumi' = '1.6.1'
+'github:pulumi/crd2pulumi' = '1.6.2'
 "vfox:version-fox/vfox-dotnet" = "8.0.20"
 `,
     );


### PR DESCRIPTION
## Summary by Sourcery

Move the generated mise configuration into the .config directory and update the pinned crd2pulumi tool version.

Bug Fixes:
- Ensure the mise configuration file is generated under .config/mise.toml instead of the project root.

Enhancements:
- Bump the crd2pulumi tool version from 1.6.1 to 1.6.2 in the generated mise configuration.

Tests:
- Update PulumiCrdSdksProject snapshot expectations for the new mise.toml location and crd2pulumi version.