### PR TITLE
fix: use the given URLs to download the CRD files

### DIFF
--- a/src/makefile.ts
+++ b/src/makefile.ts
@@ -53,7 +53,7 @@ export function createMakefile(project: Project, options: PulumiCrdSdksProjectOp
   makefile.addLine('\tmkdir -p $(CRD_DIR)');
   makefile.addLine('');
   makefile.addLine('$(CRD_DIR)/%.yaml: | $(CRD_DIR)');
-  makefile.addLine('\tcurl -sL -o $@ $(subst $(CRD_DIR)/,https://github.com/cert-manager/cert-manager/raw/refs/tags/v$(VERSION)/deploy/crds/,$@)');
+  makefile.addLine('\tcurl -sL -o $@ $(filter %/$(notdir $@),$(CRD_URLS))');
   makefile.addLine('');
 
   makefile.addLine('generate_nodejs: .make/generate_nodejs');


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Fix CRD generation to download CRD files from explicitly supplied URLs instead of constructing them from a fixed GitHub path.