### PR TITLE
fix: optionally retain build artifacts

### DIFF
--- a/src/github/workflow-build-check-dirty.ts
+++ b/src/github/workflow-build-check-dirty.ts
@@ -169,7 +169,15 @@ export class WorkflowBuildCheckDirty extends projen.Component {
     buildSdk.name = 'Build SDK';
 
     buildSdk.on({
-      workflowCall: {},
+      workflowCall: {
+        inputs: {
+          retain: {
+            description: 'Whether or not to retain intermediate build artifacts',
+            default: 'false',
+            type: 'boolean',
+          },
+        },
+      },
     });
 
     const clean = {
@@ -339,6 +347,9 @@ export class WorkflowBuildCheckDirty extends projen.Component {
         contents: 'read',
       },
       uses: './.github/workflows/build_sdk.yml',
+      with: {
+        retain: 'true',
+      },
       secrets: 'inherit',
     });
     release.addJob('publish', {

--- a/src/github/workflow-build-check-dirty.ts
+++ b/src/github/workflow-build-check-dirty.ts
@@ -173,7 +173,7 @@ export class WorkflowBuildCheckDirty extends projen.Component {
         inputs: {
           retain: {
             description: 'Whether or not to retain intermediate build artifacts',
-            default: 'false',
+            default: false,
             type: 'boolean',
           },
         },

--- a/src/github/workflow-build-check-dirty.ts
+++ b/src/github/workflow-build-check-dirty.ts
@@ -348,7 +348,7 @@ export class WorkflowBuildCheckDirty extends projen.Component {
       },
       uses: './.github/workflows/build_sdk.yml',
       with: {
-        retain: 'true',
+        retain: true,
       },
       secrets: 'inherit',
     });


### PR DESCRIPTION
## Summary by Sourcery

Allow the shared build workflow to optionally retain intermediate build artifacts and enable retention for the release publish job.

New Features:
- Add a boolean workflow input to control whether intermediate build artifacts are retained in the shared SDK build workflow.

Enhancements:
- Configure the release publish job to invoke the SDK build workflow with artifact retention enabled.