### PR TITLE
fix: guard the upload step using the `retain` input setting

### DIFF
--- a/src/github/workflow-build-check-dirty.ts
+++ b/src/github/workflow-build-check-dirty.ts
@@ -212,6 +212,7 @@ export class WorkflowBuildCheckDirty extends projen.Component {
 
     const uploadSdk = {
       name: 'Upload SDK',
+      if: '${{ inputs.retain }}',
       uses: './.github/actions/upload-sdk',
       with: {
         language: '${{ matrix.language }}',


### PR DESCRIPTION
## Summary by Sourcery

Bug Fixes:
- Ensure the SDK upload step only runs when the `retain` input is enabled.